### PR TITLE
fix: replace castrojo in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @castrojo
+* @NiHaiden


### PR DESCRIPTION
We probably don't want Jorge to be the primary reviewer for Aurora PRs.